### PR TITLE
refactor: use built-in configparser to replace python-dotenv

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ name = "pypi"
 beautifulsoup4 = "==4.10.0"
 halo = {ref = "multiple-spinners", git = "git://github.com/frostming/halo/"}
 pyinquirer = "==1.0.3"
-python-dotenv = "==0.19.2"
 requests = "==2.26.0"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0e3b56f98c82bdd8b65f9a4ae62d535c6439477cdb1e75c974a4e31deca931fb"
+            "sha256": "273407cad24d10c89b4d553e6b32f045f31ce1ff7aad66a742ff2ba8b1188acf"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -88,14 +88,6 @@
             ],
             "index": "pypi",
             "version": "==1.0.3"
-        },
-        "python-dotenv": {
-            "hashes": [
-                "sha256:32b2bdc1873fd3a3c346da1c6db83d0053c3c62f28f1f38516070c4c8971b1d3",
-                "sha256:a5de49a31e953b45ff2d2fd434bbc2670e8db5273606c1e737cc6b93eff3655f"
-            ],
-            "index": "pypi",
-            "version": "==0.19.2"
         },
         "regex": {
             "hashes": [

--- a/anime1download/cli/__init__.py
+++ b/anime1download/cli/__init__.py
@@ -1,6 +1,0 @@
-"""globals attached to cli module"""
-
-from dotenv import load_dotenv
-
-# Take environment variables from .env
-load_dotenv()

--- a/anime1download/cli/downloader.py
+++ b/anime1download/cli/downloader.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import concurrent.futures
+import configparser
 from PyInquirer import prompt
 # FIXME: Use pip published version of Halo when #155 is merged
 # https://github.com/manrajgrover/halo/pull/155
@@ -12,6 +13,11 @@ from cli.exceptions import (
 )
 from cli.scraper import get_search_result, get_video_stream
 from cli.constants import CLI_VERSION
+
+# Load configurations
+config = configparser.ConfigParser()
+config_path = os.path.join(os.getcwd(), 'config.ini')
+config.read(config_path)
 
 def start():
     """Main entry function that display questions to guide user through the download journey"""
@@ -60,7 +66,7 @@ def start():
     # Create video directory for saving downloaded videos
     video_directory = os.path.join(
         os.getcwd(),
-        os.environ.get('VIDEO_DIRECTORY'),
+        config.get('CLI', 'VIDEO_DIRECTORY'),
         answer2['category']
     )
 
@@ -68,7 +74,7 @@ def start():
         os.makedirs(video_directory)
 
     # Start download
-    max_parallel_download = int(os.environ.get('MAX_PARALLEL_DOWNLOAD'))
+    max_parallel_download = int(config.get('CLI', 'MAX_PARALLEL_DOWNLOAD'))
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_parallel_download) as executor:
         executor.map(
             download_video,
@@ -114,7 +120,7 @@ def download_video(anime_info):
         # Save video stream to video directory
         file_path = os.path.join(
             os.getcwd(),
-            os.environ.get('VIDEO_DIRECTORY'),
+            config.get('CLI', 'VIDEO_DIRECTORY'),
             anime_info["category"],
             video_stream_info['file_name']
         )

--- a/config.ini
+++ b/config.ini
@@ -1,3 +1,5 @@
+[CLI]
+
 # Maximum allowed number of parallel download
 # Increasing the value will result in a faster download time
 # but might reduce the stability of connections


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Remove the use of `python-dotenv` and use `configparser` that is built-in ny Python

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
1. Manually start and run the program

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [ ] Bug fix - `fix`
- [x] Refactor - `refactor`
- [ ] Test cases - `test`
- [ ] Other(s): <!-- Fill the type of changes here -->

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
