### PR TITLE
ci: run build check also on master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,17 @@
 name: Build
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
     branches:
-      - 'develop'
+      - develop
+      - master
     tags-ignore:
-      - '**' # prevent double build on release tag
+      - '**' # prevent duplicate builds for any push of release tags
+  pull_request:
+    branches:
+      # triggers when base branch is integration branch of feature branches
+      # or develop, exclude master
+      - '**'
+      - '!master'
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Adjust triggering condition for GitHub action used for build check so that it runs also on push commits of master branch

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
N/A

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [ ] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test cases - `test`
- [x] Other(s): `ci`

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
